### PR TITLE
merchantry rebalance

### DIFF
--- a/code/modules/cargo/supply_packs/armor.dm
+++ b/code/modules/cargo/supply_packs/armor.dm
@@ -137,7 +137,7 @@
 
 /datum/supply_pack/armor/bracers//only until we get the iron bracers/jack of plates ingame
 	name = "Steel Bracers"
-	cost = 30
+	cost = 50 // This should not be allowed but if it exists, make it expensive as hell as a punishment.
 	contains = /obj/item/clothing/wrists/bracers
 
 /datum/supply_pack/armor/angle_gloves

--- a/code/modules/cargo/supply_packs/armor.dm
+++ b/code/modules/cargo/supply_packs/armor.dm
@@ -3,27 +3,43 @@
 	crate_name = "merchant guild's crate"
 	crate_type = /obj/structure/closet/crate/chest/merchant
 
-/datum/supply_pack/armor/skullcap
+/datum/supply_pack/armor/fullplated
+	name ="Full plate armor"
+	cost = 95
+	contains = /obj/item/clothing/armor/plate/iron//hhahahahhahh they didn't said what material is made out, the only heavy armor for sale.
+
+/datum/supply_pack/armor/hardenedhelmet//poor armor options
+	name ="hardened leather helmet"
+	cost = 10
+	contains = /obj/item/clothing/head/helmet/leather/conical
+
+/datum/supply_pack/armor/paddedcoif
+	name = "padded coif"
+	cost = 10
+	contains = /obj/item/clothing/neck/coif/cloth
+
+/datum/supply_pack/armor/copperchest
+	name ="copper chestplate"
+	cost = 18
+	contains = /obj/item/clothing/armor/cuirass/copperchest
+
+/datum/supply_pack/armor/skullcap//poorest helmet on market, becomes ash if smelted
 	name = "Skullcap Helmet"
-	cost = 27
+	cost = 14
 	contains = /obj/item/clothing/head/helmet/skullcap
 
-/datum/supply_pack/armor/minerhelmet
-	name = "Miner's Helm"
-	cost = 25
-	contains = /obj/item/clothing/head/helmet/leather/minershelm
-
-/datum/supply_pack/armor/poth
+/datum/supply_pack/armor/poth//average option who can be smelted into iron
 	name = "Pot Helmet"
-	cost = 29
+	cost = 25
 	contains = /obj/item/clothing/head/helmet/ironpot
 
-/datum/supply_pack/armor/nasalh
+/datum/supply_pack/armor/nasalh//best option aviable and only steel piece, it melts to ash so isn't free steel
 	name = "Nasal Helmet"
-	cost = 31
+	cost = 30
 	contains = /obj/item/clothing/head/helmet/nasal
 
-/datum/supply_pack/armor/sallet
+//NO STEEL ON MERCHANT GUILD
+/*/datum/supply_pack/armor/sallet
 	name = "Sallet Helmet"
 	cost = 35
 	contains = /obj/item/clothing/head/helmet/sallet
@@ -43,84 +59,85 @@
 	cost = 73
 	contains = /obj/item/clothing/head/helmet/heavy/bucket
 
+*/
 /datum/supply_pack/armor/imask
 	name = "Iron Facemask"
-	cost = 31
+	cost = 25
 	contains = /obj/item/clothing/face/facemask
 
-/datum/supply_pack/armor/smask
-	name = "Steel Facemask"
-	cost = 39
-	contains = /obj/item/clothing/face/facemask/steel
+//datum/supply_pack/armor/smask
+//	name = "Steel Facemask"
+//	cost = 39
+//	contains = /obj/item/clothing/face/facemask/steel
 
 /datum/supply_pack/armor/chaincoif_iron
 	name = "Iron Chain Coif"
-	cost = 27
+	cost = 25
 	contains = /obj/item/clothing/neck/chaincoif/iron
 
-/datum/supply_pack/armor/chaincoif_steel
-	name = "Steel Chain Coif"
-	cost = 40
-	contains = /obj/item/clothing/neck/chaincoif
+///datum/supply_pack/armor/chaincoif_steel
+//	name = "Steel Chain Coif"
+//	cost = 40
+//	contains = /obj/item/clothing/neck/chaincoif
 
 /datum/supply_pack/armor/gambeson
 	name = "Cloth Gambeson"
-	cost = 24
+	cost = 15
 	contains = /obj/item/clothing/armor/gambeson
 
 /datum/supply_pack/armor/leather_armor
 	name = "Leather Armor"
-	cost = 26
+	cost = 18
 	contains = /obj/item/clothing/armor/leather
 
 /datum/supply_pack/armor/studleather
 	name = "Studded Leather Armor"
-	cost = 33
+	cost = 30
 	contains = /obj/item/clothing/armor/leather/splint
 
-/datum/supply_pack/armor/studleather_masterwork
-	name = "Masterwork Leather Armor"
-	cost = 63
-	contains = /obj/item/clothing/armor/leather/masterwork
+///datum/supply_pack/armor/studleather_masterwork
+//	name = "Masterwork Leather Armor"
+//	cost = 63
+//	contains = /obj/item/clothing/armor/leather/masterwork
 
 /datum/supply_pack/armor/chainmail_iron
 	name = "Iron Chainmail"
-	cost = 35
+	cost = 25
 	contains = /obj/item/clothing/armor/chainmail/iron
 
-/datum/supply_pack/armor/chainmail_hauberk
-	name = "Hauberk"
-	cost = 55
-	contains = /obj/item/clothing/armor/chainmail/hauberk
+///datum/supply_pack/armor/chainmail_hauberk
+//	name = "Hauberk"
+//	cost = 55
+//	contains = /obj/item/clothing/armor/chainmail/hauberk
 
 /datum/supply_pack/armor/cuirass_iron
 	name = "Iron Cuirass"
-	cost = 45
+	cost = 30//is one bad armor
 	contains = /obj/item/clothing/armor/cuirass/iron
 
-/datum/supply_pack/armor/cuirass
-	name = "Steel Cuirass"
-	cost = 50
-	contains = /obj/item/clothing/armor/cuirass
+///datum/supply_pack/armor/cuirass
+//	name = "Steel Cuirass"
+//	cost = 50
+//	contains = /obj/item/clothing/armor/cuirass
 
-/datum/supply_pack/armor/brigandine
-	name = "Brigandine"
-	cost = 100
-	contains = /obj/item/clothing/armor/brigandine
+///datum/supply_pack/armor/brigandine
+//	name = "Brigandine"
+//	cost = 100
+//	contains = /obj/item/clothing/armor/brigandine
 
-/datum/supply_pack/armor/coatofplates
-	name = "Coat Of Plates"
-	cost = 110
-	contains = /obj/item/clothing/armor/brigandine/coatplates
+///datum/supply_pack/armor/coatofplates
+//	name = "Coat Of Plates"
+//	cost = 110
+//	contains = /obj/item/clothing/armor/brigandine/coatplates
 
 /datum/supply_pack/armor/leather_bracers
 	name = "Leather Bracers"
 	cost = 15
 	contains = /obj/item/clothing/wrists/bracers/leather
 
-/datum/supply_pack/armor/bracers
+/datum/supply_pack/armor/bracers//only until we get the iron bracers/jack of plates ingame
 	name = "Steel Bracers"
-	cost = 29
+	cost = 30
 	contains = /obj/item/clothing/wrists/bracers
 
 /datum/supply_pack/armor/angle_gloves
@@ -130,40 +147,40 @@
 
 /datum/supply_pack/armor/chain_gloves_iron
 	name = "Iron Chain Gloves"
-	cost = 26
+	cost = 25
 	contains = /obj/item/clothing/gloves/chain/iron
 
-/datum/supply_pack/armor/plate_gloves
-	name = "Heavy Plate Gloves"
-	cost = 34
-	contains = /obj/item/clothing/gloves/plate
+///datum/supply_pack/armor/plate_gloves
+//	name = "Heavy Plate Gloves"
+//	cost = 34
+//	contains = /obj/item/clothing/gloves/plate
 
 /datum/supply_pack/armor/chainlegs_iron
 	name = "Iron Chain Chausses"
-	cost = 29
+	cost = 25
 	contains = /obj/item/clothing/pants/chainlegs/iron
 
-/datum/supply_pack/armor/chainlegs_steel
-	name = "Steel Chain Chausses"
-	cost = 33
-	contains = /obj/item/clothing/pants/chainlegs
+///datum/supply_pack/armor/chainlegs_steel
+//	name = "Steel Chain Chausses"
+//	cost = 33
+//	contains = /obj/item/clothing/pants/chainlegs
 
 /datum/supply_pack/armor/chainkilt_iron
 	name = "Iron Chain Kilt"
-	cost = 29
+	cost = 25
 	contains = /obj/item/clothing/pants/chainlegs/kilt/iron
 
-/datum/supply_pack/armor/chainkilt_steel
-	name = "Steel Chain Kilt"
-	cost = 33
-	contains = /obj/item/clothing/pants/chainlegs/kilt
+///datum/supply_pack/armor/chainkilt_steel
+//	name = "Steel Chain Kilt"
+//	cost = 33
+//	contains = /obj/item/clothing/pants/chainlegs/kilt
 
 /datum/supply_pack/armor/light_armor_boots
 	name = "Iron Boots"
 	cost = 27
 	contains = /obj/item/clothing/shoes/boots/armor/light
 
-/datum/supply_pack/armor/steel_boots
-	name = "Plate Boots"
-	cost = 32
-	contains = /obj/item/clothing/shoes/boots/armor
+///datum/supply_pack/armor/steel_boots
+//	name = "Plate Boots"
+//	cost = 32
+//	contains = /obj/item/clothing/shoes/boots/armor

--- a/code/modules/cargo/supply_packs/drinks.dm
+++ b/code/modules/cargo/supply_packs/drinks.dm
@@ -8,17 +8,17 @@
 	cost = 18
 	contains = /obj/item/reagent_containers/glass/bottle/manapot
 
-/datum/supply_pack/food/stronghealthpot
+///datum/supply_pack/food/stronghealthpot
 
-	name = "Strong Healing Potion"
-	cost = 38
-	contains = /obj/item/reagent_containers/glass/bottle/stronghealthpot
+//	name = "Strong Healing Potion"
+//	cost = 38
+//	contains = /obj/item/reagent_containers/glass/bottle/stronghealthpot
 
-/datum/supply_pack/food/strongmanapot
+///datum/supply_pack/food/strongmanapot
 
-	name = "Strong Manna Potion"
-	cost = 32
-	contains = /obj/item/reagent_containers/glass/bottle/strongmanapot
+//	name = "Strong Manna Potion"
+//	cost = 32
+//	contains = /obj/item/reagent_containers/glass/bottle/strongmanapot
 
 /datum/supply_pack/food/antidote
 

--- a/code/modules/cargo/supply_packs/rawmat.dm
+++ b/code/modules/cargo/supply_packs/rawmat.dm
@@ -121,12 +121,13 @@
 		/obj/item/alch/sinew,
 		/obj/item/alch/sinew
 	)
-/datum/supply_pack/rawmats/riddle_of_steel
+/*/datum/supply_pack/rawmats/riddle_of_steel yeah thug hunter, this one is out
 	name = "Riddle of Steel"
 	cost = 1100
 	contains = list(
 		/obj/item/riddleofsteel
 	)
+*/
 
 /datum/supply_pack/rawmats/lumber
 	name = "Lumber"

--- a/code/modules/cargo/supply_packs/weapons.dm
+++ b/code/modules/cargo/supply_packs/weapons.dm
@@ -45,7 +45,7 @@
 
 /datum/supply_pack/weapons/waraxe
 	name = "Iron war Axe"
-	cost = 30 //a bit more since is 2 iron bars to make, and deadlier
+	cost = 40 //a bit more since is 2 iron bars to make, and deadlier
 	contains = /obj/item/weapon/polearm/halberd/bardiche/warcutter
 
 ///datum/supply_pack/weapons/saxe

--- a/code/modules/cargo/supply_packs/weapons.dm
+++ b/code/modules/cargo/supply_packs/weapons.dm
@@ -13,10 +13,10 @@
 	cost = 27
 	contains = /obj/item/weapon/sword/iron
 
-/datum/supply_pack/weapons/sword
-	name = "Steel Arming Sword"
-	cost = 30
-	contains = /obj/item/weapon/sword
+///datum/supply_pack/weapons/sword
+//	name = "Steel Arming Sword"
+//	cost = 30
+//	contains = /obj/item/weapon/sword
 
 /datum/supply_pack/weapons/greatsword
 	name = "Iron Zweihander"
@@ -28,10 +28,10 @@
 	cost = 28
 	contains = /obj/item/weapon/mace
 
-/datum/supply_pack/weapons/smace
-	name = "Flanged Steel Mace"
-	cost = 28
-	contains = /obj/item/weapon/mace/steel
+///datum/supply_pack/weapons/smace
+//	name = "Flanged Steel Mace"
+//	cost = 28
+//	contains = /obj/item/weapon/mace/steel
 
 /datum/supply_pack/weapons/greatmace
 	name = "Iron Warclub"
@@ -43,15 +43,20 @@
 	cost = 26
 	contains = /obj/item/weapon/axe
 
-/datum/supply_pack/weapons/saxe
-	name = "Steel Axe"
-	cost = 29
-	contains = /obj/item/weapon/axe/steel
+/datum/supply_pack/weapons/waraxe
+	name = "Iron war Axe"
+	cost = 30 //a bit more since is 2 iron bars to make, and deadlier
+	contains = /obj/item/weapon/polearm/halberd/bardiche/warcutter
 
-/datum/supply_pack/weapons/halberd
-	name = "Halberd"
-	cost = 51
-	contains = /obj/item/weapon/polearm/halberd
+///datum/supply_pack/weapons/saxe
+//	name = "Steel Axe"
+//	cost = 29
+//	contains = /obj/item/weapon/axe/steel
+
+///datum/supply_pack/weapons/halberd
+//	name = "Halberd"
+//	cost = 51
+//	contains = /obj/item/weapon/polearm/halberd
 
 /datum/supply_pack/weapons/huntingknife
 	name = "Iron Hunting Knife"
@@ -63,10 +68,10 @@
 	cost = 22
 	contains = /obj/item/weapon/knife/dagger
 
-/datum/supply_pack/weapons/sdagger
-	name = "Steel Dagger"
-	cost = 26
-	contains = /obj/item/weapon/knife/dagger/steel
+///datum/supply_pack/weapons/sdagger
+//	name = "Steel Dagger"
+//	cost = 26
+//	contains = /obj/item/weapon/knife/dagger/steel
 
 /datum/supply_pack/weapons/spear
 	name = "Iron Spear"
@@ -78,10 +83,10 @@
 	cost = 29
 	contains = /obj/item/weapon/flail
 
-/datum/supply_pack/weapons/sflail
-	name = "Steel Flail"
-	cost = 32
-	contains = /obj/item/weapon/flail/sflail
+///datum/supply_pack/weapons/sflail
+//	name = "Steel Flail"
+//	cost = 32
+//	contains = /obj/item/weapon/flail/sflail
 
 /datum/supply_pack/weapons/whip
 	name = "Leather Whip"
@@ -157,12 +162,18 @@
 	cost = 2
 	contains = /obj/item/ammo_casing/caseless/bolt
 
-/datum/supply_pack/weapons/tossbladeiron
-	name = "Iron Tossblade Belt"
-	cost = 20
-	contains = /obj/item/storage/belt/leather/knifebelt/black/iron
+///datum/supply_pack/weapons/tossbladeiron
+//	name = "Iron Tossblade Belt"
+//	cost = 20
+//	contains = /obj/item/storage/belt/leather/knifebelt/black/iron
 
-/datum/supply_pack/weapons/tossbladesteel
-	name = "Steel Tossblade Belt"
-	cost = 40
-	contains = /obj/item/storage/belt/leather/knifebelt/black/steel
+///datum/supply_pack/weapons/tossbladesteel
+//	name = "Steel Tossblade Belt"
+//	cost = 40
+//	contains = /obj/item/storage/belt/leather/knifebelt/black/steel
+
+/datum/supply_pack/weapons/tossbladeiron//trowing belts are banned due to extremely big storage, not the knifes even if they are limited to iron
+	name = "Iron Tossblade"
+	cost = 20
+	contains =/obj/item/weapon/knife/throwingknife
+


### PR DESCRIPTION
## About The Pull Request

rebalances the merchantry items, removing steel pieces, strong potions, steel riddle import.

adds poor armors to the list and more iron replacements, including copper, padded cloth and leather as cheap options

rebalances the prices of armors, having in mind that everyone is more poor now having all the medium pouches removed and only 10 mammons on their account

## Why It's Good For The Game

is totally good if we want to have a fun balanced game 

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

