### PR TITLE
deity boon removal

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -124,7 +124,7 @@
 	flaws = "Carelessness, Aggression, Pride"
 	worshippers = "Warriors, Sellswords, Guardsmen"
 	sins = "Cowardice, Cruelty, Stagnation"
-	boons = "Your used weapons dull slower."
+	boons = "None."
 	//added_traits = list(TRAIT_SHARPER_BLADES)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/self/call_to_arms

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -24,7 +24,7 @@
 	flaws = "Tyrannical, Ill-Tempered, Uncompromising"
 	worshippers = "Nobles, Zealots, Commoners"
 	sins = "Betrayal, Sloth, Witchcraft"
-	boons = "Your stamina regeneration delay is lowered during daytime."
+	boons = "None."
 	//added_traits = list(TRAIT_APRICITY)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/sacred_flame_rogue

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -84,7 +84,7 @@
 	flaws= "Reckless, Stubborn, Destructive"
 	worshippers = "Sailors of the Sea and Sky, Horrid Sea-Creachers, Fog Islanders"
 	sins = "Fear, Hubris, Forgetfulness"
-	boons = "Leeches will drain very little of your blood."
+	boons = "None."
 	//added_traits = list(TRAIT_LEECHIMMUNE)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/projectile/swordfish

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -64,7 +64,7 @@
 	flaws = "Madness, Rebelliousness, Disorderliness"
 	worshippers = "Druids, Beasts, Madmen"
 	sins = "Deforestation, Overhunting, Disrespecting Nature"
-	boons = "You are immune to kneestingers."
+	boons = "None."
 	//added_traits = list(TRAIT_KNEESTINGER_IMMUNITY)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/targeted/blesscrop

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -25,7 +25,7 @@
 	worshippers = "Nobles, Zealots, Commoners"
 	sins = "Betrayal, Sloth, Witchcraft"
 	boons = "Your stamina regeneration delay is lowered during daytime."
-	added_traits = list(TRAIT_APRICITY)
+	//added_traits = list(TRAIT_APRICITY)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/sacred_flame_rogue
 	t2 = /obj/effect/proc_holder/spell/invoked/heal
@@ -45,7 +45,7 @@
 	worshippers = "Magic Practitioners, Scholars, Scribes"
 	sins = "Suppressing Truth, Burning Books, Censorship"
 	boons = "You learn, dream, and teach apprentices slightly better."
-	added_traits = list(TRAIT_TUTELAGE)
+	//added_traits = list(TRAIT_TUTELAGE)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/invisibility
 	t2 = /obj/effect/proc_holder/spell/invoked/blindness/miracle
@@ -65,7 +65,7 @@
 	worshippers = "Druids, Beasts, Madmen"
 	sins = "Deforestation, Overhunting, Disrespecting Nature"
 	boons = "You are immune to kneestingers."
-	added_traits = list(TRAIT_KNEESTINGER_IMMUNITY)
+	//added_traits = list(TRAIT_KNEESTINGER_IMMUNITY)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/targeted/blesscrop
 	t2 = /obj/effect/proc_holder/spell/self/beastsense
@@ -85,7 +85,7 @@
 	worshippers = "Sailors of the Sea and Sky, Horrid Sea-Creachers, Fog Islanders"
 	sins = "Fear, Hubris, Forgetfulness"
 	boons = "Leeches will drain very little of your blood."
-	added_traits = list(TRAIT_LEECHIMMUNE)
+	//added_traits = list(TRAIT_LEECHIMMUNE)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/projectile/swordfish
 	t2 = /obj/effect/proc_holder/spell/self/summon_trident
@@ -105,7 +105,7 @@
 	worshippers = "Orderlies, Gravetenders, Mourners"
 	sins = "Heretical Magic, Untimely Death, Disturbance of Rest"
 	boons = "You may see the presence of a soul in a body."
-	added_traits = list(TRAIT_SOUL_EXAMINE)
+	//added_traits = list(TRAIT_SOUL_EXAMINE)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/targeted/burialrite
 	t2 = /obj/effect/proc_holder/spell/targeted/soulspeak
@@ -125,7 +125,7 @@
 	worshippers = "Warriors, Sellswords, Guardsmen"
 	sins = "Cowardice, Cruelty, Stagnation"
 	boons = "Your used weapons dull slower."
-	added_traits = list(TRAIT_SHARPER_BLADES)
+	//added_traits = list(TRAIT_SHARPER_BLADES)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/self/call_to_arms
 	t2 = /obj/effect/proc_holder/spell/self/divine_strike
@@ -145,7 +145,7 @@
 	worshippers = "Cheats, Performers, The Hopeless"
 	sins = "Boredom, Predictability, Routine"
 	boons = "You can rig different forms of gambling in your favor."
-	added_traits = list(TRAIT_BLACKLEG)
+	//added_traits = list(TRAIT_BLACKLEG)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/vicious_mimicry
 	t2 = /obj/effect/proc_holder/spell/invoked/wheel
@@ -171,7 +171,7 @@
 	worshippers = "The Ill and Infirm, Alchemists, Physicians"
 	sins = "´Curing´ Abnormalities, Refusing to Help Unfortunates, Groveling"
 	boons = "You may consume rotten food without being sick."
-	added_traits = list(TRAIT_ROT_EATER)
+	//added_traits = list(TRAIT_ROT_EATER)
 	t0 = /obj/effect/proc_holder/spell/invoked/diagnose
 	t1 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t2 = /obj/effect/proc_holder/spell/invoked/attach_bodypart
@@ -191,7 +191,7 @@
 	worshippers = "Smiths, Miners, Sculptors"
 	sins = "Cheating, Shoddy Work, Suicide"
 	boons = "You recover more energy when sleeping."
-	added_traits = list(TRAIT_BETTER_SLEEP)
+	//added_traits = list(TRAIT_BETTER_SLEEP)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/vigorouscraft
 	t2 = /obj/effect/proc_holder/spell/invoked/hammerfall
@@ -211,7 +211,7 @@
 	worshippers = "Mothers, Artists, Married Couples"
 	sins = "Sadism, Abandonment, Ruining Beauty"
 	boons = "You can understand others' needs better."
-	added_traits = list(TRAIT_EXTEROCEPTION)
+	//added_traits = list(TRAIT_EXTEROCEPTION)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/instill_perfection
 	t2 = /obj/effect/proc_holder/spell/invoked/projectile/eoracurse

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -44,7 +44,7 @@
 	flaws = "Cynical, Isolationist, Unfiltered Honesty"
 	worshippers = "Magic Practitioners, Scholars, Scribes"
 	sins = "Suppressing Truth, Burning Books, Censorship"
-	boons = "You learn, dream, and teach apprentices slightly better."
+	boons = "None."
 	//added_traits = list(TRAIT_TUTELAGE)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/invisibility

--- a/code/modules/client/preferences/_preferences.dm
+++ b/code/modules/client/preferences/_preferences.dm
@@ -1020,7 +1020,7 @@ GLOBAL_LIST_INIT(name_adjustments, list())
 						to_chat(user, "<font color='purple'>Flawed aspects: [selected_patron.flaws]</font>")
 						to_chat(user, "<font color='purple'>Likely Worshippers: [selected_patron.worshippers]</font>")
 						to_chat(user, "<font color='red'>Considers these to be Sins: [selected_patron.sins]</font>")
-						to_chat(user, "<font color='white'>Blessed with boon(s): [selected_patron.boons]</font>")
+//to_chat(user, "<font color='white'>Blessed with boon(s): [selected_patron.boons]</font>")
 
 				if("voice")
 					var/new_voice = input(user, "SELECT YOUR HERO'S VOICE COLOR", "THE THROAT","#"+voice_color) as color|null

--- a/modular/stonekeep/code/gods.dm
+++ b/modular/stonekeep/code/gods.dm
@@ -7,8 +7,8 @@
 	flaws = "Tyrannical, Ill-Tempered, Uncompromising"
 	worshippers = "Nobles, Zealots, Commoners"
 	sins = "Betrayal, Sloth, Witchcraft"
-	boons = "Your stamina regeneration delay is lowered during daytime."
-	added_traits = list(TRAIT_APRICITY)
+	//boons = "Your stamina regeneration delay is lowered during daytime."
+	//added_traits = list(TRAIT_APRICITY)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/sacred_flame_rogue
 	t2 = /obj/effect/proc_holder/spell/invoked/heal
@@ -26,8 +26,8 @@
 	flaws = "Cynical, Isolationist, Unfiltered Honesty"
 	worshippers = "Magic Practitioners, Scholars, Scribes"
 	sins = "Suppressing Truth, Indulging Lust, Destroying Books"
-	boons = "You learn and teach apprentices slightly better."
-	added_traits = list(TRAIT_TUTELAGE)
+	//boons = "You learn and teach apprentices slightly better."
+	//added_traits = list(TRAIT_TUTELAGE)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/invisibility
 	t2 = /obj/effect/proc_holder/spell/invoked/blindness
@@ -45,8 +45,8 @@
 	flaws = "Madness, Rebelliousness, Disorderliness"
 	worshippers = "Druids, Beasts, Madmen"
 	sins = "Deforestation, Overhunting, Disrespecting Nature"
-	boons = "You are immune to kneestingers."
-	added_traits = list(TRAIT_KNEESTINGER_IMMUNITY)
+	//boons = "You are immune to kneestingers."
+	//added_traits = list(TRAIT_KNEESTINGER_IMMUNITY)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/targeted/blesscrop
 	t2 = /obj/effect/proc_holder/spell/self/beastsense
@@ -64,8 +64,8 @@
 	flaws= "Unforgiving, Stubborn, Destructive"
 	worshippers = "Sailors of the Sea and Sky, Horrid Sea-Creachers, Fog Islanders"
 	sins = "Fear, Hubris, Forgetfulness"
-	boons = "Leeches will not latch onto you in dirty water."
-	added_traits = list(TRAIT_LEECHIMMUNE)
+	//boons = "Leeches will not latch onto you in dirty water."
+	//added_traits = list(TRAIT_LEECHIMMUNE)
 /* NEEDS KAIZOKU TO WORK ROGTODO
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal/abyssal
 	t1 = /obj/effect/proc_holder/spell/invoked/projectile/purify
@@ -89,8 +89,8 @@
 	flaws = "Unchanging, Apathetic, Strict"
 	worshippers = "Dark Elves, Gravekeepers, Mourners"
 	sins = "Undeath"
-	boons = "You may see the presence of a soul in a body."
-	added_traits = list(TRAIT_SOUL_EXAMINE)
+	//boons = "You may see the presence of a soul in a body."
+	//added_traits = list(TRAIT_SOUL_EXAMINE)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/targeted/burialrite
 	t2 = /obj/effect/proc_holder/spell/targeted/soulspeak
@@ -108,8 +108,8 @@
 	flaws = "Careless, Aggressive, Prideful"
 	worshippers = "Warriors, Sellswords, Guardsmen"
 	sins = "Cowardice, Hesitation, Stagnation"
-	boons = "Your used weapons dull slower."
-	added_traits = list(TRAIT_SHARPER_BLADES)
+	//boons = "Your used weapons dull slower."
+	//added_traits = list(TRAIT_SHARPER_BLADES)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/self/call_to_arms
 	t2 = /obj/effect/proc_holder/spell/self/divine_strike
@@ -127,8 +127,8 @@
 	flaws = "Petulance, Deception, Gambling-Prone"
 	worshippers = "Cheats, Performers, The Hopeless"
 	sins = "Boredom, Predictability, Routine"
-	boons = "You can rig different forms of gambling in your favor."
-	added_traits = list(TRAIT_BLACKLEG)
+	//boons = "You can rig different forms of gambling in your favor."
+	//added_traits = list(TRAIT_BLACKLEG)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/vicious_mimicry
 	t2 = /obj/effect/proc_holder/spell/invoked/wheel
@@ -152,8 +152,8 @@
 	flaws = "Drunkard, Crude, Sloppy"
 	worshippers = "The Ill and Infirm, Alchemists, Physicians"
 	sins = "´Curing´ Abnormalities, Refusing to help the ill, Failure to prepare"
-	boons = "You may consume rotten food without being sick."
-	added_traits = list(TRAIT_ROT_EATER)
+	//boons = "You may consume rotten food without being sick."
+	//added_traits = list(TRAIT_ROT_EATER)
 	t0 = /obj/effect/proc_holder/spell/invoked/diagnose
 	t1 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t2 = /obj/effect/proc_holder/spell/invoked/attach_bodypart
@@ -171,8 +171,8 @@
 	flaws = "Obsessive, Exacting, Overbearing"
 	worshippers = "Smiths, Miners, Sculptors"
 	sins = "Cheating, Shoddy Work, Suicide"
-	boons = "You recover more energy when sleeping."
-	added_traits = list(TRAIT_BETTER_SLEEP)
+	//boons = "You recover more energy when sleeping."
+	//added_traits = list(TRAIT_BETTER_SLEEP)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/vigorouscraft
 	t2 = /obj/effect/proc_holder/spell/invoked/hammerfall
@@ -190,8 +190,8 @@
 	flaws= "Naive, Impulsive, Ignorant"
 	worshippers = "Mothers, Artists, Married Couples"
 	sins = "Sadism, Abandonment, Ruining Beauty"
-	boons = "You can understand others' needs better."
-	added_traits = list(TRAIT_EXTEROCEPTION)
+	//boons = "You can understand others' needs better."
+	//added_traits = list(TRAIT_EXTEROCEPTION)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/instill_perfection
 	t2 = /obj/effect/proc_holder/spell/invoked/projectile/eoracurse


### PR DESCRIPTION
## About The Pull Request

removes the powerful gaming device from the pantheon gods, inhumens keep their bonuses
![dreamseeker_CNUc0huPOb](https://github.com/user-attachments/assets/f5d66516-075f-4c44-a6bd-924707318e82)
![dreamseeker_LGftRybj5d](https://github.com/user-attachments/assets/5b6174df-ac78-40cb-a3a8-30fad6288d7c)



## Why It's Good For The Game

too powerful to balance for normal players, acolytes/clerics/paladins should have these bonuses

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
